### PR TITLE
Update __main__.py

### DIFF
--- a/CDNDrive/__main__.py
+++ b/CDNDrive/__main__.py
@@ -18,10 +18,10 @@ import time
 import traceback
 import types
 from concurrent.futures import ThreadPoolExecutor
-from . import __version__
-from .drivers import *
-from .encoders import *
-from .util import *
+from CDNDrive import __version__
+from CDNDrive.drivers import *
+from CDNDrive.encoders import *
+from CDNDrive.util import *
 
 encoder = None
 api = None


### PR DESCRIPTION
fix single run error by `python .\CDNDrive\__main__.py`, it also fix pyinstaller compile to exe file
![image](https://user-images.githubusercontent.com/48424802/130609183-ffa77f02-3a75-441a-90bc-e9a403683e39.png)
